### PR TITLE
Fixing presentation mode crashing app.

### DIFF
--- a/TilingWindowManager/Core/WindowManager.cs
+++ b/TilingWindowManager/Core/WindowManager.cs
@@ -701,6 +701,7 @@ namespace TilingWindowManager
         }
         private bool IsWindowInCurrentWorkspace(nint window)
         {
+            if (monitors == null) return false;
             foreach (var monitor in monitors)
             {
                 if (monitor.IsWindowInCurrentWorkspace(window))


### PR DESCRIPTION
Since windows is performing window movement when monitors change from extended to duplicate (mirrored) skipping the check if it is null.